### PR TITLE
fix(db-manager): Fix order of waterings

### DIFF
--- a/api/_utils/db/db-manager.ts
+++ b/api/_utils/db/db-manager.ts
@@ -145,6 +145,7 @@ export async function getLastWateredTreeById(
     `
     SELECT *
     FROM trees_watered
+    ORDER BY timestamp DESC
     WHERE trees_watered.tree_id = $1`,
     [id],
   );

--- a/api/_utils/db/db-manager.ts
+++ b/api/_utils/db/db-manager.ts
@@ -145,8 +145,8 @@ export async function getLastWateredTreeById(
     `
     SELECT *
     FROM trees_watered
-    ORDER BY timestamp DESC
-    WHERE trees_watered.tree_id = $1`,
+    WHERE trees_watered.tree_id = $1
+    ORDER BY timestamp DESC`,
     [id],
   );
   return result.rows;


### PR DESCRIPTION
This PR inserts an `ORDER BY timestamp DESC` to the `getLastWateredTreeById` call.