### PR TITLE
fix(adoption): Adds unique constrain trees_adopted

### DIFF
--- a/api/_utils/db/db-manager.test.ts
+++ b/api/_utils/db/db-manager.test.ts
@@ -311,7 +311,7 @@ describe("db-manager", () => {
       Array [
         Object {
           "adopted": null,
-          "artBot": null,
+          "artbot": null,
           "artdtsch": null,
           "baumhoehe": null,
           "bezirk": null,
@@ -320,6 +320,7 @@ describe("db-manager", () => {
           "gattung": null,
           "gattungdeutsch": null,
           "geom": null,
+          "gmlid": null,
           "hausnr": null,
           "id": "_08be12a72n",
           "kennzeich": null,

--- a/api/_utils/db/db-manager.ts
+++ b/api/_utils/db/db-manager.ts
@@ -234,11 +234,11 @@ export async function adoptTree(
   await pool.query(
     `
      INSERT INTO trees_adopted (tree_id, uuid)
-     VALUES ($1, $2);
+     VALUES ($1, $2) on conflict (tree_id, uuid) do nothing;
   `,
     [tree_id, uuid],
   );
-  // console.log(res);
+
   return `tree ${tree_id} was adopted by user ${uuid}`;
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,7 @@ model trees {
   lat            String?
   lng            String?
   artdtsch       String?
-  artBot         String?
+  artbot         String?
   gattungdeutsch String?
   gattung        String?
   strname        String?
@@ -77,6 +77,7 @@ model trees {
   standortnr     String?
   kennzeich      String?
   caretaker      String?
+  gmlid          String?
   trees_adopted  trees_adopted[]
   trees_watered  trees_watered[]
 
@@ -91,6 +92,7 @@ model trees_adopted {
   tree_id String
   trees   trees   @relation(fields: [tree_id], references: [id])
 
+  @@unique([tree_id, uuid], name: "trees_adopted_tree_id_uuid_key")
   @@index([uuid], name: "trees_adopted_uuid")
 }
 


### PR DESCRIPTION
It was possible to adopt a tree twice. Which did not create errors in
the ui but added cruft to the table trees_adopted.
Now this wont happen anymore.

You need to migrate your production DB first by
1. finding duplicates

```sql
-- find duplicates

SELECT tree_id, uuid, count(*) from trees_adopted GROUP by tree_id, uuid HAVING count(*) >1;
```

2. remove duplicates

```sql
-- remove duplicates

DELETE FROM trees_adopted AS adpt USING trees_adopted dups
WHERE adpt.id > dups.id
	AND adpt.uuid = dups.uuid
	AND adpt.tree_id = dups.tree_id;

```

3. Adding the constrain tree

```sql
-- constrain to tree_id, uuid combination

alter table trees_adopted add UNIQUE (tree_id, uuid);
```
