### PR TITLE
Update tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
           node-version-file: ".nvmrc"
       - run: npm ci
       - id: semantic-release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 18
         env:


### PR DESCRIPTION
We use a semantic release action version that will stop working soon see https://github.blog/changelog/2022-***0-***-github-actions-deprecating-save-state-and-set-output-commands/