### PR TITLE
fix(profile): Make usernames case insensitive

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["humao.rest-client", "mikestead.dotenv"]
+  "recommendations": [
+    "humao.rest-client",
+    "mikestead.dotenv",
+    "mkhl.direnv"
+  ]
 }

--- a/__test-utils/postgres.ts
+++ b/__test-utils/postgres.ts
@@ -16,15 +16,16 @@ export async function truncateTreesAdopted() {
 	sql.end();
 }
 
-export async function createWateredTrees() {
+export async function createWateredTrees(userId?: string, userName?: string) {
 	const sql = postgres(url);
+	const randomText = sql`md5(random()::text)`;
 	await sql`
 	INSERT INTO trees_watered (uuid, amount, timestamp, username, tree_id)
 	SELECT
-		md5(random()::text),
+		${userId ? userId : sql`extensions.uuid_generate_v4()::text`},
 		random() * 10,
 		NOW() - (random() * INTERVAL '7 days'),
-		md5(random()::text),
+		${userName ? userName : randomText},
 		id
 	FROM
 		trees

--- a/__test-utils/req-test-token.ts
+++ b/__test-utils/req-test-token.ts
@@ -1,9 +1,10 @@
+import { SignupResponse } from "../_types/user";
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./supabase";
 const issuer = process.env.issuer || "";
 const client_id = process.env.client_id || "";
 const client_secret = process.env.client_secret || "";
 const audience = process.env.audience || "";
-const SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
-const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "";
+
 export async function requestAuth0TestToken() {
 	const response = await fetch(`${issuer}oauth/token`, {
 		method: "POST",
@@ -47,14 +48,15 @@ export async function requestSupabaseTestToken(
 		const json = await response.text();
 		throw new Error(`Could not get test token, ${json}`);
 	}
-	const json = (await response.json()) as {
-		access_token: string;
-		user: { id: string };
-	};
+	const json = (await response.json()) as SignupResponse;
 	return json.access_token;
 }
 
-export async function createSupabaseUser(email: string, password: string) {
+export async function createSupabaseUser(
+	email: string,
+	password: string,
+	opts?: { returnFullUser: boolean }
+) {
 	const response = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
 		method: "POST",
 		headers: {
@@ -67,6 +69,7 @@ export async function createSupabaseUser(email: string, password: string) {
 		}),
 	});
 	if (!response.ok) {
+		console.log(response.status);
 		const json = await response.text();
 		throw new Error(`Could not create test user, ${json}`);
 	}
@@ -74,5 +77,8 @@ export async function createSupabaseUser(email: string, password: string) {
 		access_token: string;
 		user: { id: string };
 	};
+	if (opts?.returnFullUser) {
+		return json;
+	}
 	return json.access_token;
 }

--- a/__test-utils/supabase.ts
+++ b/__test-utils/supabase.ts
@@ -1,0 +1,16 @@
+import { createClient } from "@supabase/supabase-js";
+import { Database } from "../_types/database";
+export const SUPABASE_URL =
+	process.env.SUPABASE_URL || "http://localhost:54321";
+export const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "";
+export const SUPABASE_SERVICE_ROLE_KEY =
+	process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+
+export const supabaseAnonClient = createClient<Database>(
+	SUPABASE_URL,
+	SUPABASE_ANON_KEY
+);
+export const supabaseServiceRoleClient = createClient<Database>(
+	SUPABASE_URL,
+	SUPABASE_SERVICE_ROLE_KEY
+);

--- a/__tests__/schema.test.ts
+++ b/__tests__/schema.test.ts
@@ -1,0 +1,187 @@
+import {
+	deleteSupabaseUser,
+	truncateTreesWaterd,
+} from "../__test-utils/postgres";
+import {
+	SUPABASE_ANON_KEY,
+	SUPABASE_URL,
+	supabaseAnonClient,
+	supabaseServiceRoleClient,
+} from "../__test-utils/supabase";
+describe("misc test testing the schema function of the database", () => {
+	test("inserting an existing username should alter the new name and add a uuid at end", async () => {
+		const email1 = "someone@email.com";
+		const email2 = "someone@foo.com";
+		await deleteSupabaseUser(email1);
+		await deleteSupabaseUser(email2);
+		const password = "12345678";
+		const { data: user1, error } = await supabaseAnonClient.auth.signUp({
+			email: email1,
+			password: password,
+		});
+		const { data: user2, error: error2 } = await supabaseAnonClient.auth.signUp(
+			{
+				email: email2,
+				password: password,
+			}
+		);
+		expect(error).toBeNull();
+		expect(user1).toBeDefined();
+		expect(error2).toBeNull();
+		expect(user2).toBeDefined();
+
+		const { data: users, error: usersError } = await supabaseAnonClient
+			.from("profiles")
+			.select("*")
+			.in("id", [user1?.user?.id, user2?.user?.id]);
+
+		expect(usersError).toBeNull();
+		expect(users).toHaveLength(2);
+		expect(users?.[0].username).toBe("someone");
+		expect(users?.[1].username).not.toBe("someone");
+		expect(users?.[1].username).toContain("someone-");
+		expect(users?.[1].username).toMatch(/^someone-[a-zA-Z0-9]{6}$/);
+		await deleteSupabaseUser(email1);
+		await deleteSupabaseUser(email2);
+	});
+
+	test("a user should be able to remove its account and his associated data", async () => {
+		const email = "user@email.com";
+		await deleteSupabaseUser(email); // clean up before running
+		const { data, error } = await supabaseAnonClient.auth.signUp({
+			email: email,
+			password: "12345678",
+		});
+		expect(error).toBeNull();
+		expect(data).toBeDefined();
+		const { data: trees, error: treesError } = await supabaseAnonClient
+			.from("trees")
+			.select("*")
+			.limit(10);
+		expect(treesError).toBeNull();
+		expect(trees).toHaveLength(10);
+
+		const { data: adoptedTrees, error: adoptedTreesError } =
+			await supabaseServiceRoleClient
+				.from("trees_adopted")
+				.insert(
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					trees!.map((tree) => ({
+						uuid: data.user?.id,
+						tree_id: tree.id,
+					}))
+				)
+				.select("*");
+		expect(adoptedTreesError).toBeNull();
+		expect(adoptedTrees).toHaveLength(10);
+		const { data: userTrees, error: userTreesError } =
+			await supabaseServiceRoleClient
+				.from("trees_watered")
+				.insert(
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					trees!.map((tree) => ({
+						uuid: data.user?.id,
+						amount: 1,
+						timestamp: new Date().toISOString(),
+						username: "user",
+						tree_id: tree.id,
+					}))
+				)
+				.select("*");
+		expect(userTreesError).toBeNull();
+		expect(userTrees).toHaveLength(10);
+
+		// since wa can not pass the token to our supabase client, we need to use fetch directly
+		const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/remove_account`, {
+			method: "POST",
+			headers: {
+				apikey: SUPABASE_ANON_KEY,
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${data.session?.access_token}`,
+			},
+		});
+		expect(response.ok).toBeTruthy();
+		expect(response.status).toBe(204);
+		const { data: treesAfter, error: treesAfterError } =
+			await supabaseAnonClient
+				.from("trees_watered")
+				.select("*")
+				.eq("uuid", data.user?.id);
+		expect(treesAfterError).toBeNull();
+		expect(treesAfter).toHaveLength(0);
+
+		const { data: adoptedTreesAfter, error: adoptedTreesAfterError } =
+			await supabaseAnonClient
+				.from("trees_adopted")
+				.select("*")
+				.eq("uuid", data.user?.id);
+		expect(adoptedTreesAfterError).toBeNull();
+		expect(adoptedTreesAfter).toHaveLength(0);
+		await truncateTreesWaterd();
+	});
+
+	test("if a user changes his username all the usernames on the trees_watered table should change too", async () => {
+		const email = "foo@bar.com";
+		await deleteSupabaseUser(email);
+		await truncateTreesWaterd();
+		const { data, error } = await supabaseAnonClient.auth.signUp({
+			email: email,
+			password: "12345678",
+		});
+		expect(error).toBeNull();
+		expect(data).toBeDefined();
+		const { data: trees, error: treesError } = await supabaseAnonClient
+			.from("trees")
+			.select("*")
+			.limit(10);
+		expect(treesError).toBeNull();
+		expect(trees).toHaveLength(10);
+
+		const { data: adoptedTrees, error: adoptedTreesError } =
+			await supabaseServiceRoleClient
+				.from("trees_watered")
+				.insert(
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					trees!.map((tree) => ({
+						uuid: data.user?.id,
+						tree_id: tree.id,
+						amount: 1,
+						timestamp: new Date().toISOString(),
+						username: "foo",
+					}))
+				)
+				.select("*");
+		expect(adoptedTreesError).toBeNull();
+		expect(adoptedTrees).toHaveLength(10);
+
+		// since we cant pass our access token to change our username to our anon client we use fetch directly
+		const changeResponse = await fetch(
+			`${SUPABASE_URL}/rest/v1/profiles?id=eq.${data?.user?.id}`,
+			{
+				method: "PATCH",
+				headers: {
+					apikey: SUPABASE_ANON_KEY,
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${data.session?.access_token}`,
+				},
+				body: JSON.stringify({
+					username: "bar",
+				}),
+			}
+		);
+
+		expect(changeResponse.ok).toBeTruthy();
+		expect(changeResponse.status).toBe(204);
+
+		const { data: treesAfter, error: treesAfterError } =
+			await supabaseServiceRoleClient
+				.from("trees_watered")
+				.select("*")
+				.eq("username", "bar");
+
+		expect(treesAfterError).toBeNull();
+		expect(treesAfter).toHaveLength(10);
+		await deleteSupabaseUser(email);
+		await truncateTreesWaterd();
+	});
+});

--- a/__tests__/schema.test.ts
+++ b/__tests__/schema.test.ts
@@ -46,6 +46,7 @@ describe("misc test testing the schema function of the database", () => {
 	});
 
 	test("a user should be able to remove its account and his associated data", async () => {
+		const numberOfTrees = 10;
 		const email = "user@email.com";
 		await deleteSupabaseUser(email); // clean up before running
 		const { data, error } = await supabaseAnonClient.auth.signUp({
@@ -57,9 +58,9 @@ describe("misc test testing the schema function of the database", () => {
 		const { data: trees, error: treesError } = await supabaseAnonClient
 			.from("trees")
 			.select("*")
-			.limit(10);
+			.limit(numberOfTrees);
 		expect(treesError).toBeNull();
-		expect(trees).toHaveLength(10);
+		expect(trees).toHaveLength(numberOfTrees);
 
 		const { data: adoptedTrees, error: adoptedTreesError } =
 			await supabaseServiceRoleClient
@@ -73,7 +74,7 @@ describe("misc test testing the schema function of the database", () => {
 				)
 				.select("*");
 		expect(adoptedTreesError).toBeNull();
-		expect(adoptedTrees).toHaveLength(10);
+		expect(adoptedTrees).toHaveLength(numberOfTrees);
 		const { data: userTrees, error: userTreesError } =
 			await supabaseServiceRoleClient
 				.from("trees_watered")
@@ -89,7 +90,7 @@ describe("misc test testing the schema function of the database", () => {
 				)
 				.select("*");
 		expect(userTreesError).toBeNull();
-		expect(userTrees).toHaveLength(10);
+		expect(userTrees).toHaveLength(numberOfTrees);
 
 		// since wa can not pass the token to our supabase client, we need to use fetch directly
 		const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/remove_account`, {
@@ -122,6 +123,7 @@ describe("misc test testing the schema function of the database", () => {
 
 	test("if a user changes his username all the usernames on the trees_watered table should change too", async () => {
 		const email = "foo@bar.com";
+		const numberOfTrees = 10;
 		await deleteSupabaseUser(email);
 		await truncateTreesWaterd();
 		const { data, error } = await supabaseAnonClient.auth.signUp({
@@ -133,9 +135,9 @@ describe("misc test testing the schema function of the database", () => {
 		const { data: trees, error: treesError } = await supabaseAnonClient
 			.from("trees")
 			.select("*")
-			.limit(10);
+			.limit(numberOfTrees);
 		expect(treesError).toBeNull();
-		expect(trees).toHaveLength(10);
+		expect(trees).toHaveLength(numberOfTrees);
 
 		const { data: adoptedTrees, error: adoptedTreesError } =
 			await supabaseServiceRoleClient
@@ -152,7 +154,7 @@ describe("misc test testing the schema function of the database", () => {
 				)
 				.select("*");
 		expect(adoptedTreesError).toBeNull();
-		expect(adoptedTrees).toHaveLength(10);
+		expect(adoptedTrees).toHaveLength(numberOfTrees);
 
 		// since we cant pass our access token to change our username to our anon client we use fetch directly
 		const changeResponse = await fetch(
@@ -180,7 +182,7 @@ describe("misc test testing the schema function of the database", () => {
 				.eq("username", "bar");
 
 		expect(treesAfterError).toBeNull();
-		expect(treesAfter).toHaveLength(10);
+		expect(treesAfter).toHaveLength(numberOfTrees);
 		await deleteSupabaseUser(email);
 		await truncateTreesWaterd();
 	});

--- a/_types/database.ts
+++ b/_types/database.ts
@@ -1,407 +1,458 @@
 export type Json =
-	| string
-	| number
-	| boolean
-	| null
-	| { [key: string]: Json }
-	| Json[];
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[]
 
 export interface Database {
-	graphql_public: {
-		Tables: {
-			[_ in never]: never;
-		};
-		Views: {
-			[_ in never]: never;
-		};
-		Functions: {
-			graphql: {
-				Args: {
-					operationName: string;
-					query: string;
-					variables: Json;
-					extensions: Json;
-				};
-				Returns: Json;
-			};
-		};
-		Enums: {
-			[_ in never]: never;
-		};
-	};
-	public: {
-		Tables: {
-			profiles: {
-				Row: {
-					id: string;
-					username: string | null;
-				};
-				Insert: {
-					id: string;
-					username?: string | null;
-				};
-				Update: {
-					id?: string;
-					username?: string | null;
-				};
-			};
-			radolan_data: {
-				Row: {
-					geom_id: number | null;
-					id: number;
-					measured_at: string | null;
-					value: number | null;
-				};
-				Insert: {
-					geom_id?: number | null;
-					id?: number;
-					measured_at?: string | null;
-					value?: number | null;
-				};
-				Update: {
-					geom_id?: number | null;
-					id?: number;
-					measured_at?: string | null;
-					value?: number | null;
-				};
-			};
-			radolan_geometry: {
-				Row: {
-					centroid: unknown | null;
-					geometry: unknown | null;
-					id: number;
-				};
-				Insert: {
-					centroid?: unknown | null;
-					geometry?: unknown | null;
-					id?: number;
-				};
-				Update: {
-					centroid?: unknown | null;
-					geometry?: unknown | null;
-					id?: number;
-				};
-			};
-			radolan_harvester: {
-				Row: {
-					collection_date: string | null;
-					end_date: string | null;
-					id: number;
-					start_date: string | null;
-				};
-				Insert: {
-					collection_date?: string | null;
-					end_date?: string | null;
-					id?: number;
-					start_date?: string | null;
-				};
-				Update: {
-					collection_date?: string | null;
-					end_date?: string | null;
-					id?: number;
-					start_date?: string | null;
-				};
-			};
-			radolan_temp: {
-				Row: {
-					geometry: unknown | null;
-					id: number;
-					measured_at: string | null;
-					value: number | null;
-				};
-				Insert: {
-					geometry?: unknown | null;
-					id?: number;
-					measured_at?: string | null;
-					value?: number | null;
-				};
-				Update: {
-					geometry?: unknown | null;
-					id?: number;
-					measured_at?: string | null;
-					value?: number | null;
-				};
-			};
-			trees: {
-				Row: {
-					adopted: string | null;
-					artbot: string | null;
-					artdtsch: string | null;
-					baumhoehe: string | null;
-					bezirk: string | null;
-					caretaker: string | null;
-					eigentuemer: string | null;
-					gattung: string | null;
-					gattungdeutsch: string | null;
-					geom: unknown | null;
-					gmlid: string | null;
-					hausnr: string | null;
-					id: string;
-					kennzeich: string | null;
-					kronedurch: string | null;
-					lat: string | null;
-					lng: string | null;
-					pflanzjahr: number | null;
-					radolan_days: number[] | null;
-					radolan_sum: number | null;
-					stammumfg: string | null;
-					standalter: string | null;
-					standortnr: string | null;
-					strname: string | null;
-					type: string | null;
-					watered: string | null;
-					zusatz: string | null;
-				};
-				Insert: {
-					adopted?: string | null;
-					artbot?: string | null;
-					artdtsch?: string | null;
-					baumhoehe?: string | null;
-					bezirk?: string | null;
-					caretaker?: string | null;
-					eigentuemer?: string | null;
-					gattung?: string | null;
-					gattungdeutsch?: string | null;
-					geom?: unknown | null;
-					gmlid?: string | null;
-					hausnr?: string | null;
-					id: string;
-					kennzeich?: string | null;
-					kronedurch?: string | null;
-					lat?: string | null;
-					lng?: string | null;
-					pflanzjahr?: number | null;
-					radolan_days?: number[] | null;
-					radolan_sum?: number | null;
-					stammumfg?: string | null;
-					standalter?: string | null;
-					standortnr?: string | null;
-					strname?: string | null;
-					type?: string | null;
-					watered?: string | null;
-					zusatz?: string | null;
-				};
-				Update: {
-					adopted?: string | null;
-					artbot?: string | null;
-					artdtsch?: string | null;
-					baumhoehe?: string | null;
-					bezirk?: string | null;
-					caretaker?: string | null;
-					eigentuemer?: string | null;
-					gattung?: string | null;
-					gattungdeutsch?: string | null;
-					geom?: unknown | null;
-					gmlid?: string | null;
-					hausnr?: string | null;
-					id?: string;
-					kennzeich?: string | null;
-					kronedurch?: string | null;
-					lat?: string | null;
-					lng?: string | null;
-					pflanzjahr?: number | null;
-					radolan_days?: number[] | null;
-					radolan_sum?: number | null;
-					stammumfg?: string | null;
-					standalter?: string | null;
-					standortnr?: string | null;
-					strname?: string | null;
-					type?: string | null;
-					watered?: string | null;
-					zusatz?: string | null;
-				};
-			};
-			trees_adopted: {
-				Row: {
-					id: number;
-					tree_id: string;
-					uuid: string | null;
-				};
-				Insert: {
-					id?: number;
-					tree_id: string;
-					uuid?: string | null;
-				};
-				Update: {
-					id?: number;
-					tree_id?: string;
-					uuid?: string | null;
-				};
-			};
-			trees_watered: {
-				Row: {
-					amount: number;
-					id: number;
-					time: string | null;
-					timestamp: string;
-					tree_id: string;
-					username: string | null;
-					uuid: string | null;
-				};
-				Insert: {
-					amount: number;
-					id?: number;
-					time?: string | null;
-					timestamp: string;
-					tree_id: string;
-					username?: string | null;
-					uuid?: string | null;
-				};
-				Update: {
-					amount?: number;
-					id?: number;
-					time?: string | null;
-					timestamp?: string;
-					tree_id?: string;
-					username?: string | null;
-					uuid?: string | null;
-				};
-			};
-		};
-		Views: {
-			[_ in never]: never;
-		};
-		Functions: {
-			count_by_age: {
-				Args: { start_year: number; end_year: number };
-				Returns: number;
-			};
-			get_watered_and_adopted: {
-				Args: Record<PropertyKey, never>;
-				Returns: { tree_id: string; adopted: number; watered: number }[];
-			};
-		};
-		Enums: {
-			[_ in never]: never;
-		};
-	};
-	storage: {
-		Tables: {
-			buckets: {
-				Row: {
-					created_at: string | null;
-					id: string;
-					name: string;
-					owner: string | null;
-					public: boolean | null;
-					updated_at: string | null;
-				};
-				Insert: {
-					created_at?: string | null;
-					id: string;
-					name: string;
-					owner?: string | null;
-					public?: boolean | null;
-					updated_at?: string | null;
-				};
-				Update: {
-					created_at?: string | null;
-					id?: string;
-					name?: string;
-					owner?: string | null;
-					public?: boolean | null;
-					updated_at?: string | null;
-				};
-			};
-			migrations: {
-				Row: {
-					executed_at: string | null;
-					hash: string;
-					id: number;
-					name: string;
-				};
-				Insert: {
-					executed_at?: string | null;
-					hash: string;
-					id: number;
-					name: string;
-				};
-				Update: {
-					executed_at?: string | null;
-					hash?: string;
-					id?: number;
-					name?: string;
-				};
-			};
-			objects: {
-				Row: {
-					bucket_id: string | null;
-					created_at: string | null;
-					id: string;
-					last_accessed_at: string | null;
-					metadata: Json | null;
-					name: string | null;
-					owner: string | null;
-					path_tokens: string[] | null;
-					updated_at: string | null;
-				};
-				Insert: {
-					bucket_id?: string | null;
-					created_at?: string | null;
-					id?: string;
-					last_accessed_at?: string | null;
-					metadata?: Json | null;
-					name?: string | null;
-					owner?: string | null;
-					path_tokens?: string[] | null;
-					updated_at?: string | null;
-				};
-				Update: {
-					bucket_id?: string | null;
-					created_at?: string | null;
-					id?: string;
-					last_accessed_at?: string | null;
-					metadata?: Json | null;
-					name?: string | null;
-					owner?: string | null;
-					path_tokens?: string[] | null;
-					updated_at?: string | null;
-				};
-			};
-		};
-		Views: {
-			[_ in never]: never;
-		};
-		Functions: {
-			extension: {
-				Args: { name: string };
-				Returns: string;
-			};
-			filename: {
-				Args: { name: string };
-				Returns: string;
-			};
-			foldername: {
-				Args: { name: string };
-				Returns: string[];
-			};
-			get_size_by_bucket: {
-				Args: Record<PropertyKey, never>;
-				Returns: { size: number; bucket_id: string }[];
-			};
-			search: {
-				Args: {
-					prefix: string;
-					bucketname: string;
-					limits: number;
-					levels: number;
-					offsets: number;
-					search: string;
-					sortcolumn: string;
-					sortorder: string;
-				};
-				Returns: {
-					name: string;
-					id: string;
-					updated_at: string;
-					created_at: string;
-					last_accessed_at: string;
-					metadata: Json;
-				}[];
-			};
-		};
-		Enums: {
-			[_ in never]: never;
-		};
-	};
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          operationName?: string
+          query?: string
+          variables?: Json
+          extensions?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string
+          username: string | null
+        }
+        Insert: {
+          id: string
+          username?: string | null
+        }
+        Update: {
+          id?: string
+          username?: string | null
+        }
+      }
+      radolan_data: {
+        Row: {
+          geom_id: number | null
+          id: number
+          measured_at: string | null
+          value: number | null
+        }
+        Insert: {
+          geom_id?: number | null
+          id?: number
+          measured_at?: string | null
+          value?: number | null
+        }
+        Update: {
+          geom_id?: number | null
+          id?: number
+          measured_at?: string | null
+          value?: number | null
+        }
+      }
+      radolan_geometry: {
+        Row: {
+          centroid: unknown | null
+          geometry: unknown | null
+          id: number
+        }
+        Insert: {
+          centroid?: unknown | null
+          geometry?: unknown | null
+          id?: number
+        }
+        Update: {
+          centroid?: unknown | null
+          geometry?: unknown | null
+          id?: number
+        }
+      }
+      radolan_harvester: {
+        Row: {
+          collection_date: string | null
+          end_date: string | null
+          id: number
+          start_date: string | null
+        }
+        Insert: {
+          collection_date?: string | null
+          end_date?: string | null
+          id?: number
+          start_date?: string | null
+        }
+        Update: {
+          collection_date?: string | null
+          end_date?: string | null
+          id?: number
+          start_date?: string | null
+        }
+      }
+      radolan_temp: {
+        Row: {
+          geometry: unknown | null
+          id: number
+          measured_at: string | null
+          value: number | null
+        }
+        Insert: {
+          geometry?: unknown | null
+          id?: number
+          measured_at?: string | null
+          value?: number | null
+        }
+        Update: {
+          geometry?: unknown | null
+          id?: number
+          measured_at?: string | null
+          value?: number | null
+        }
+      }
+      trees: {
+        Row: {
+          adopted: string | null
+          artbot: string | null
+          artdtsch: string | null
+          baumhoehe: string | null
+          bezirk: string | null
+          caretaker: string | null
+          eigentuemer: string | null
+          gattung: string | null
+          gattungdeutsch: string | null
+          geom: unknown | null
+          gmlid: string | null
+          hausnr: string | null
+          id: string
+          kennzeich: string | null
+          kronedurch: string | null
+          lat: string | null
+          lng: string | null
+          pflanzjahr: number | null
+          radolan_days: number[] | null
+          radolan_sum: number | null
+          stammumfg: string | null
+          standalter: string | null
+          standortnr: string | null
+          strname: string | null
+          type: string | null
+          watered: string | null
+          zusatz: string | null
+        }
+        Insert: {
+          adopted?: string | null
+          artbot?: string | null
+          artdtsch?: string | null
+          baumhoehe?: string | null
+          bezirk?: string | null
+          caretaker?: string | null
+          eigentuemer?: string | null
+          gattung?: string | null
+          gattungdeutsch?: string | null
+          geom?: unknown | null
+          gmlid?: string | null
+          hausnr?: string | null
+          id: string
+          kennzeich?: string | null
+          kronedurch?: string | null
+          lat?: string | null
+          lng?: string | null
+          pflanzjahr?: number | null
+          radolan_days?: number[] | null
+          radolan_sum?: number | null
+          stammumfg?: string | null
+          standalter?: string | null
+          standortnr?: string | null
+          strname?: string | null
+          type?: string | null
+          watered?: string | null
+          zusatz?: string | null
+        }
+        Update: {
+          adopted?: string | null
+          artbot?: string | null
+          artdtsch?: string | null
+          baumhoehe?: string | null
+          bezirk?: string | null
+          caretaker?: string | null
+          eigentuemer?: string | null
+          gattung?: string | null
+          gattungdeutsch?: string | null
+          geom?: unknown | null
+          gmlid?: string | null
+          hausnr?: string | null
+          id?: string
+          kennzeich?: string | null
+          kronedurch?: string | null
+          lat?: string | null
+          lng?: string | null
+          pflanzjahr?: number | null
+          radolan_days?: number[] | null
+          radolan_sum?: number | null
+          stammumfg?: string | null
+          standalter?: string | null
+          standortnr?: string | null
+          strname?: string | null
+          type?: string | null
+          watered?: string | null
+          zusatz?: string | null
+        }
+      }
+      trees_adopted: {
+        Row: {
+          id: number
+          tree_id: string
+          uuid: string | null
+        }
+        Insert: {
+          id?: number
+          tree_id: string
+          uuid?: string | null
+        }
+        Update: {
+          id?: number
+          tree_id?: string
+          uuid?: string | null
+        }
+      }
+      trees_watered: {
+        Row: {
+          amount: number
+          id: number
+          time: string | null
+          timestamp: string
+          tree_id: string
+          username: string | null
+          uuid: string | null
+        }
+        Insert: {
+          amount: number
+          id?: number
+          time?: string | null
+          timestamp: string
+          tree_id: string
+          username?: string | null
+          uuid?: string | null
+        }
+        Update: {
+          amount?: number
+          id?: number
+          time?: string | null
+          timestamp?: string
+          tree_id?: string
+          username?: string | null
+          uuid?: string | null
+        }
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      count_by_age: {
+        Args: {
+          start_year: number
+          end_year: number
+        }
+        Returns: number
+      }
+      get_watered_and_adopted: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          tree_id: string
+          adopted: number
+          watered: number
+        }[]
+      }
+      remove_account: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  storage: {
+    Tables: {
+      buckets: {
+        Row: {
+          allowed_mime_types: string[] | null
+          avif_autodetection: boolean | null
+          created_at: string | null
+          file_size_limit: number | null
+          id: string
+          name: string
+          owner: string | null
+          public: boolean | null
+          updated_at: string | null
+        }
+        Insert: {
+          allowed_mime_types?: string[] | null
+          avif_autodetection?: boolean | null
+          created_at?: string | null
+          file_size_limit?: number | null
+          id: string
+          name: string
+          owner?: string | null
+          public?: boolean | null
+          updated_at?: string | null
+        }
+        Update: {
+          allowed_mime_types?: string[] | null
+          avif_autodetection?: boolean | null
+          created_at?: string | null
+          file_size_limit?: number | null
+          id?: string
+          name?: string
+          owner?: string | null
+          public?: boolean | null
+          updated_at?: string | null
+        }
+      }
+      migrations: {
+        Row: {
+          executed_at: string | null
+          hash: string
+          id: number
+          name: string
+        }
+        Insert: {
+          executed_at?: string | null
+          hash: string
+          id: number
+          name: string
+        }
+        Update: {
+          executed_at?: string | null
+          hash?: string
+          id?: number
+          name?: string
+        }
+      }
+      objects: {
+        Row: {
+          bucket_id: string | null
+          created_at: string | null
+          id: string
+          last_accessed_at: string | null
+          metadata: Json | null
+          name: string | null
+          owner: string | null
+          path_tokens: string[] | null
+          updated_at: string | null
+          version: string | null
+        }
+        Insert: {
+          bucket_id?: string | null
+          created_at?: string | null
+          id?: string
+          last_accessed_at?: string | null
+          metadata?: Json | null
+          name?: string | null
+          owner?: string | null
+          path_tokens?: string[] | null
+          updated_at?: string | null
+          version?: string | null
+        }
+        Update: {
+          bucket_id?: string | null
+          created_at?: string | null
+          id?: string
+          last_accessed_at?: string | null
+          metadata?: Json | null
+          name?: string | null
+          owner?: string | null
+          path_tokens?: string[] | null
+          updated_at?: string | null
+          version?: string | null
+        }
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      can_insert_object: {
+        Args: {
+          bucketid: string
+          name: string
+          owner: string
+          metadata: Json
+        }
+        Returns: undefined
+      }
+      extension: {
+        Args: {
+          name: string
+        }
+        Returns: string
+      }
+      filename: {
+        Args: {
+          name: string
+        }
+        Returns: string
+      }
+      foldername: {
+        Args: {
+          name: string
+        }
+        Returns: string[]
+      }
+      get_size_by_bucket: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          size: number
+          bucket_id: string
+        }[]
+      }
+      search: {
+        Args: {
+          prefix: string
+          bucketname: string
+          limits?: number
+          levels?: number
+          offsets?: number
+          search?: string
+          sortcolumn?: string
+          sortorder?: string
+        }
+        Returns: {
+          name: string
+          id: string
+          updated_at: string
+          created_at: string
+          last_accessed_at: string
+          metadata: Json
+        }[]
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
 }
+

--- a/_types/user.ts
+++ b/_types/user.ts
@@ -1,0 +1,38 @@
+export interface SignupResponse {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	refresh_token: string;
+	user: User;
+}
+export interface User {
+	id: string;
+	aud: string;
+	role: string;
+	email: string;
+	email_confirmed_at: string;
+	phone: string;
+	last_sign_in_at: string;
+	app_metadata: AppMetadata;
+	user_metadata: Record<string, unknown>;
+	identities?: IdentitiesEntity[] | null;
+	created_at: string;
+	updated_at: string;
+}
+export interface AppMetadata {
+	provider: string;
+	providers?: string[] | null;
+}
+export interface IdentitiesEntity {
+	id: string;
+	user_id: string;
+	identity_data: IdentityData;
+	provider: string;
+	last_sign_in_at: string;
+	created_at: string;
+	updated_at: string;
+}
+export interface IdentityData {
+	email: string;
+	sub: string;
+}

--- a/supabase/migrations/20230419150648_unique_username_case_insensitive.sql
+++ b/supabase/migrations/20230419150648_unique_username_case_insensitive.sql
@@ -1,0 +1,13 @@
+CREATE EXTENSION IF NOT EXISTS "citext" WITH SCHEMA "extensions";
+
+ALTER TABLE "public"."profiles"
+	DROP CONSTRAINT "username_length_constraint";
+
+ALTER TABLE "public"."profiles"
+	ALTER COLUMN "username" SET data TYPE citext USING "username"::citext;
+
+ALTER TABLE "public"."profiles"
+	ADD CONSTRAINT "username_length_constraint" CHECK (((length((username)::text) >= 3) AND (length((username)::text) <= 50))) NOT valid;
+
+ALTER TABLE "public"."profiles" validate CONSTRAINT "username_length_constraint";
+

--- a/supabase/migrations/20230419165714_fix_username_uuid_trigger.sql
+++ b/supabase/migrations/20230419165714_fix_username_uuid_trigger.sql
@@ -1,0 +1,21 @@
+SET check_function_bodies = OFF;
+
+CREATE OR REPLACE FUNCTION public.username_append_uuid()
+	RETURNS TRIGGER
+	LANGUAGE plpgsql
+	AS $function$
+BEGIN
+	IF EXISTS(
+		SELECT
+			1
+		FROM
+			public.profiles
+		WHERE
+			username = NEW.username) THEN
+	NEW.username := NEW.username || '-' || TRIM(BOTH FROM SUBSTRING(
+		LEFT(extensions.uuid_generate_v4()::text, 8), 1, 6));
+END IF;
+	RETURN NEW;
+END;
+$function$;
+

--- a/supabase/migrations/20230419180719_chore_make_delete_silent.sql
+++ b/supabase/migrations/20230419180719_chore_make_delete_silent.sql
@@ -1,0 +1,31 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.delete_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+	row_count int;
+BEGIN
+	DELETE FROM public.profiles p
+	WHERE p.id = OLD.id;
+-- 	IF found THEN
+-- 		GET DIAGNOSTICS row_count = ROW_COUNT;
+-- 		RAISE NOTICE 'DELETEd % row(s) FROM profiles', row_count;
+-- 	END IF;
+	UPDATE
+		trees_watered
+	SET
+		uuid = NULL,
+		username = NULL
+	WHERE
+		uuid = OLD.id::text;
+	DELETE FROM trees_adopted ta
+	WHERE ta.uuid = OLD.id::text;
+	RETURN OLD;
+END;
+$function$
+;
+
+

--- a/supabase/tests/database/unique_names.test.sql
+++ b/supabase/tests/database/unique_names.test.sql
@@ -1,0 +1,6 @@
+begin;
+select plan(1); -- only one statement to run
+
+
+SELECT * FROM finish();
+rollback;


### PR DESCRIPTION
This PR 

- fix(profile): Make usernames case insensitive 74034e5

This is done by using the citext extensions.
Once we have imported all the users from auth0 we will remove the
uuid trigger function and only have the DB reject duplicate names

- fix(schema): Update call to uuid generate 6f69042

The trigger function that adds an uuid to the username if we have duplicates did throw an error when executed by adding a user with the same name as an existing one. This still will be removed when we are migrated.

- fix(schema): Update outdated types f2c3f3e
- chore(schema): Remove logging from delete function 28110dd
- chore: Used extension on this project f0f3e78

## Test

- test(schema): Verify functions in schema c238268

This surfaced some errors we had in the schema. Like you can see in the fixes above

- test(utils): Update test utils for schema tests be85f2b and  e9a3c80
- test: Boilerplate of schema tests. WIP 0c2096f
 

