### PR TITLE
fix: Enforce email confirmation locally

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,7 +56,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.


### PR DESCRIPTION
Hm. This kills lot of unit tests and would make it way more complicated. Wont be merged.
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204421189240931