### PR TITLE
feat: 25 trees of each artbot in seed.sql

### DIFF
--- a/__tests__/parse-content-range.test.ts
+++ b/__tests__/parse-content-range.test.ts
@@ -15,8 +15,8 @@ describe("getRange", () => {
 		expect(result.error).toBeNull();
 		expect(result.range).toEqual({
 			start: 0,
-			end: 13,
-			total: 14,
+			end: 12779,
+			total: 12780,
 		} as ContentRange);
 	});
 
@@ -27,7 +27,7 @@ describe("getRange", () => {
 	});
 
 	test("should return full range", async () => {
-		const expected = { end: 13, start: 0, total: 14 };
+		const expected = { end: 12779, start: 0, total: 12780 };
 		const { error, range: result } = await getRange(
 			`${SUPABASE_URL}/rest/v1/trees`
 			//


### PR DESCRIPTION
I added 25 trees of each artbot to seed.sql. Fetched the trees with: 

```
WITH ranked_trees AS (
  SELECT
    *,
    ROW_NUMBER() OVER (PARTITION BY artbot ORDER BY artbot) AS row_num
  FROM trees
)
SELECT "id", "lat", "lng", "artdtsch", "artbot", "gattungdeutsch", "gattung", "strname", "hausnr", "zusatz", "pflanzjahr", "standalter", "kronedurch", "stammumfg", "type", "baumhoehe", "bezirk", "eigentuemer", "adopted", "watered", "radolan_sum", "radolan_days", "geom", "standortnr", "kennzeich", "caretaker", "gmlid"
FROM ranked_trees
WHERE row_num <= 25
ORDER BY artbot;
```