### PR TITLE
feat(username): Add username during signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,3 +363,4 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 [gdk-supabase]: https://github.com/technologiestiftung/giessdenkiez-de-supabase/
 [supabase]: https://supabase.com/
+<!-- bump -->

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -59,7 +59,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = true
+enable_confirmations = false
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -59,7 +59,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.

--- a/supabase/migrations/20240125144049_signup_set_sername.sql
+++ b/supabase/migrations/20240125144049_signup_set_sername.sql
@@ -1,0 +1,19 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+	INSERT INTO public.profiles (id, username)
+		VALUES(NEW.id, (
+				SELECT
+					COALESCE(NEW.raw_user_meta_data ->> 'signup_username', REGEXP_REPLACE(NEW.email, '@.*?$', ''))));
+	RETURN new;
+END;
+$function$
+;
+
+


### PR DESCRIPTION
This PR is the companion to https://github.com/technologiestiftung/giessdenkiez-de/pull/668

It reads from the `auth.users.raw_user_meta_data->>signup_username` the name that gets passed on signup via

```js
    const { data, error } = await supabase.auth.signUp({
      email,
      password,
      options: {
        data: {
          signup_username: username,
        },
      },
    });
```

during the execution of the `public.handle_new_user trigger` when a new user is added to `auth.users`.

To test this locally you need to set `enable_confirmations = true` in `subase/config.toml`

TODO:

- [ ] Setup some cron routine that removes this field once the user confirmed his email.