### PR TITLE
chore: update Supabase CLI version in workflows

### DIFF
--- a/.github/workflows/deploy-to-supabase-production.yml
+++ b/.github/workflows/deploy-to-supabase-production.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.142.2
+          version: 2.19.7
 
       - run: |
           supabase link --project-ref $PRODUCTION_PROJECT_ID

--- a/.github/workflows/deploy-to-supabase-staging.yml
+++ b/.github/workflows/deploy-to-supabase-staging.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.142.2
+          version: 2.19.7
 
       - run: |
           supabase link --project-ref $STAGING_PROJECT_ID


### PR DESCRIPTION
- Updated Supabase CLI version from 1.142.2 to 2.19.7 in both production and staging deployment workflows.
